### PR TITLE
Add superuser fixture and AdminLTE admin theme

### DIFF
--- a/core/fixtures/superuser.json
+++ b/core/fixtures/superuser.json
@@ -1,0 +1,16 @@
+[
+  {
+    "model": "auth.user",
+    "pk": 1,
+    "fields": {
+      "username": "nacho",
+      "email": "nacho@nacho.es",
+      "password": "pbkdf2_sha256$1000000$VxEYZyS8Uzp5eIrXPjMbDW$RhRtReoLZPnLUSyH7JX8gKV89imdXVGJ0w8ltG0AS2Y=",
+      "is_superuser": true,
+      "is_staff": true,
+      "is_active": true,
+      "first_name": "",
+      "last_name": ""
+    }
+  }
+]

--- a/core/templates/admin/base_site.html
+++ b/core/templates/admin/base_site.html
@@ -1,0 +1,13 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css">
+  {% include "adminlte_sidebar_css_snippet.html" %}
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <script src="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/js/adminlte.min.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add fixture for nacho superuser
- style Django admin with AdminLTE assets

## Testing
- `python3 -m json.tool core/fixtures/superuser.json`
- `python3 manage.py check` *(fails: Unknown field(s) (estado) specified for Pedido)*

------
https://chatgpt.com/codex/tasks/task_e_68946072ef0c8321af3e364e5a4a0b5f