### PR TITLE
docs: añadir instrucciones de instalación

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,62 @@
+FAPP
+====
+
+Configuración del entorno
+-------------------------
+
+1. Instala Python 3 si aún no lo tienes.
+2. Crea un entorno virtual y actívalo:
+
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+3. Instala las dependencias del proyecto:
+
+   ```bash
+   pip install django psycopg2-binary
+   ```
+
+Base de datos
+-------------
+
+1. Asegúrate de tener un servidor de PostgreSQL en funcionamiento.
+2. Crea la base de datos y el usuario con las credenciales definidas en `fapp/settings.py`:
+
+   ```sql
+   CREATE DATABASE fappdb;
+   CREATE USER fappuser WITH PASSWORD 'fapppass';
+   GRANT ALL PRIVILEGES ON DATABASE fappdb TO fappuser;
+   ```
+
+Migraciones y servidor
+----------------------
+
+1. Aplica las migraciones:
+
+   ```bash
+   python manage.py migrate
+   ```
+2. (Opcional) Crea un superusuario para acceder al panel de administración:
+
+   ```bash
+   python manage.py createsuperuser
+   ```
+3. Arranca el servidor de desarrollo:
+
+   ```bash
+   python manage.py runserver
+   ```
+
+Cargar datos de ejemplo
+-----------------------
+
+Puedes cargar datos de ejemplo utilizando fixtures de Django.
+Coloca un archivo JSON con los datos en una carpeta `fixtures/` y ejecuta:
+
+```bash
+python manage.py loaddata datos_ejemplo.json
+```
+
+Esto poblará la base de datos con la información definida en el archivo.
+


### PR DESCRIPTION
## Resumen
- documentar configuración de entorno, instalación de dependencias y puesta en marcha del servidor
- añadir pasos para crear la base de datos y ejecutar migraciones
- incluir guía para cargar datos de ejemplo

## Pruebas
- `python manage.py test` *(falla: Unknown field(s) (estado) specified for Pedido)*

------
https://chatgpt.com/codex/tasks/task_e_68946074f92c8321b61496a973beb19d