### PR TITLE
feat: add export utilities and database scripts

### DIFF
--- a/core/templates/core/clientes_pdf.html
+++ b/core/templates/core/clientes_pdf.html
@@ -18,7 +18,7 @@
         <th>CIF</th>
         <th>Email</th>
         <th>Teléfono</th>
-        <th>Localidad</th>
+        <th>Dirección</th>
         <th>Activo</th>
       </tr>
     </thead>
@@ -29,7 +29,7 @@
         <td>{{ c.cif }}</td>
         <td>{{ c.email }}</td>
         <td>{{ c.telefono }}</td>
-        <td>{{ c.localidad }}</td>
+        <td>{{ c.direccion }}</td>
         <td>{{ c.activo|yesno:"Sí,No" }}</td>
       </tr>
       {% endfor %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -11,6 +11,8 @@ urlpatterns = [
     path('clientes/nuevo/', views.cliente_nuevo, name='cliente_nuevo'),
     path('clientes/editar/<int:pk>/', views.cliente_editar, name='cliente_editar'),
     path('clientes/export/csv/', views.cliente_export_csv, name='cliente_export_csv'),
+    path('clientes/export/pdf/', views.cliente_export_pdf, name='cliente_export_pdf'),
+    path('clientes/print/html/', views.cliente_print_html, name='cliente_print_html'),
 
     # Presupuestos
     path('presupuestos/', views.presupuestos_list, name='presupuestos_list'),

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,43 @@
+import csv
+from django.http import HttpResponse
+from django.template.loader import get_template
+from xhtml2pdf import pisa
+
+
+def export_csv(queryset, fields, filename="export.csv"):
+    """Generate a CSV HttpResponse for the given queryset.
+
+    Args:
+        queryset (Iterable): Django queryset or list of objects.
+        fields (Iterable): Field names or (attribute, header) tuples.
+        filename (str): Name for the downloaded file.
+    """
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = f"attachment; filename=\"{filename}\""
+    writer = csv.writer(response)
+    headers = [label if isinstance(field, (tuple, list)) else field for field in fields]
+    writer.writerow(headers)
+    for obj in queryset:
+        row = []
+        for field in fields:
+            attr = field[0] if isinstance(field, (tuple, list)) else field
+            value = getattr(obj, attr)
+            row.append(value)
+        writer.writerow(row)
+    return response
+
+
+def export_pdf(template_path, context, filename="export.pdf"):
+    """Render a template to PDF using xhtml2pdf."""
+    template = get_template(template_path)
+    html = template.render(context)
+    response = HttpResponse(content_type="application/pdf")
+    response["Content-Disposition"] = f"attachment; filename=\"{filename}\""
+    pisa.CreatePDF(html, dest=response)
+    return response
+
+
+def render_html(template_path, context):
+    """Render a template for HTML printing."""
+    template = get_template(template_path)
+    return HttpResponse(template.render(context))

--- a/core/views.py
+++ b/core/views.py
@@ -1,10 +1,11 @@
 
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse
+
 from .models import Cliente, Presupuesto, Pedido, Actuacion, Factura
 from .forms import ClienteForm, PresupuestoForm
-from django.http import HttpResponse
-import csv
+from .utils import export_csv, export_pdf, render_html
 
 @login_required
 def dashboard(request):
@@ -41,13 +42,27 @@ def cliente_editar(request, pk):
 
 @login_required
 def cliente_export_csv(request):
-    response = HttpResponse(content_type='text/csv')
-    response['Content-Disposition'] = 'attachment; filename="clientes.csv"'
-    writer = csv.writer(response)
-    writer.writerow(['Nombre', 'Email', 'Teléfono'])
-    for cliente in Cliente.objects.all():
-        writer.writerow([cliente.nombre, cliente.email, cliente.telefono])
-    return response
+    queryset = Cliente.objects.all()
+    fields = [
+        ('nombre', 'Nombre'),
+        ('email', 'Email'),
+        ('telefono', 'Teléfono'),
+    ]
+    return export_csv(queryset, fields, 'clientes.csv')
+
+
+@login_required
+def cliente_export_pdf(request):
+    clientes = Cliente.objects.all()
+    context = {'clientes': clientes}
+    return export_pdf('core/clientes_pdf.html', context, 'clientes.pdf')
+
+
+@login_required
+def cliente_print_html(request):
+    clientes = Cliente.objects.all()
+    context = {'clientes': clientes}
+    return render_html('core/clientes_pdf.html', context)
 
 # --- Presupuestos ---
 @login_required

--- a/scripts/create_db.sql
+++ b/scripts/create_db.sql
@@ -1,0 +1,4 @@
+-- Script to create database and user for FAPP
+CREATE DATABASE fapp;
+CREATE USER fappuser WITH ENCRYPTED PASSWORD 'fapp1234';
+GRANT ALL PRIVILEGES ON DATABASE fapp TO fappuser;

--- a/scripts/initial_data.sql
+++ b/scripts/initial_data.sql
@@ -1,0 +1,6 @@
+-- Optional initial data for FAPP
+INSERT INTO core_usuario (id, username, password, is_superuser, is_staff, is_active, date_joined)
+VALUES (1, 'admin', 'pbkdf2_sha256$600000$JrwId25yhTkQFiZX6AocXa$UNUGpXvQZkjwU6VrTMfwu/Le1gu8fafnwz0vGfAyrfk=', true, true, true, NOW());
+
+INSERT INTO core_cliente (id, usuario_id, nombre, cif, direccion, email, telefono, activo)
+VALUES (1, 1, 'Cliente Demo', '00000000A', 'Calle Falsa 123', 'cliente@demo.com', '600000000', true);


### PR DESCRIPTION
## Summary
- add utilities to export querysets to CSV, PDF and printable HTML
- implement PDF/HTML export views for clientes and expose new routes
- include PostgreSQL database setup and optional seed scripts

## Testing
- `python manage.py test` *(fails: Unknown field(s) (estado) specified for Pedido)*

------
https://chatgpt.com/codex/tasks/task_e_68946073ad908321af74af71b2c97c36