### PR TITLE
Add CRUD and export test coverage with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          python manage.py test --settings=fapp.settings_test

--- a/clientes/tests.py
+++ b/clientes/tests.py
@@ -1,0 +1,59 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from core.models import Cliente
+
+
+@override_settings(ROOT_URLCONF="test_urls")
+class ClienteCRUDTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="user", password="pass")
+        self.client.force_login(self.user)
+
+    def test_create_cliente(self):
+        response = self.client.post(
+            reverse("clientes:cliente_create"),
+            {
+                "nombre": "Cliente",
+                "email": "cli@example.com",
+                "telefono": "123",
+                "direccion": "Calle",
+            },
+        )
+        self.assertRedirects(response, reverse("clientes:cliente_list"), fetch_redirect_response=False)
+        self.assertEqual(Cliente.objects.count(), 1)
+
+    def test_edit_cliente(self):
+        cliente = Cliente.objects.create(usuario=self.user, nombre="Old")
+        response = self.client.post(
+            reverse("clientes:cliente_edit", args=[cliente.pk]),
+            {
+                "nombre": "New",
+                "email": "",
+                "telefono": "",
+                "direccion": "",
+            },
+        )
+        self.assertRedirects(response, reverse("clientes:cliente_list"), fetch_redirect_response=False)
+        cliente.refresh_from_db()
+        self.assertEqual(cliente.nombre, "New")
+
+    def test_delete_cliente(self):
+        cliente = Cliente.objects.create(usuario=self.user, nombre="Del")
+        response = self.client.post(reverse("clientes:cliente_delete", args=[cliente.pk]))
+        self.assertRedirects(response, reverse("clientes:cliente_list"), fetch_redirect_response=False)
+        self.assertEqual(Cliente.objects.count(), 0)
+
+    def test_export_csv(self):
+        Cliente.objects.create(usuario=self.user, nombre="CSV")
+        response = self.client.get(reverse("clientes:cliente_export_csv"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"CSV", response.content)
+
+    def test_export_pdf(self):
+        Cliente.objects.create(usuario=self.user, nombre="PDF")
+        response = self.client.get(reverse("clientes:cliente_export_pdf"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertTrue(response.content.startswith(b"%PDF"))

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,8 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
-
 from django.contrib.auth import get_user_model
-from .models import Cliente, Pedido, Factura
+from .models import Cliente, Pedido, Factura, Actuacion
 
 
 class FacturaTests(TestCase):
@@ -48,23 +47,37 @@ class FacturaTests(TestCase):
         self.assertIn(b"F001", response.content)
 
 
-class PedidoEditTests(TestCase):
+class PedidoCRUDTests(TestCase):
     def setUp(self):
         User = get_user_model()
         self.user = User.objects.create_user(username="user", password="pass")
+        self.client.force_login(self.user)
         self.cliente = Cliente.objects.create(usuario=self.user, nombre="Cliente")
-        self.pedido = Pedido.objects.create(
+
+    def test_create_pedido(self):
+        response = self.client.post(
+            reverse("pedido_nuevo"),
+            {
+                "cliente": self.cliente.pk,
+                "presupuesto": "",
+                "fecha": "2024-01-01",
+                "descripcion": "Pedido nuevo",
+                "total": 100,
+            },
+        )
+        self.assertRedirects(response, reverse("pedidos_list"), fetch_redirect_response=False)
+        self.assertEqual(Pedido.objects.count(), 1)
+
+    def test_edit_pedido(self):
+        pedido = Pedido.objects.create(
             usuario=self.user,
             cliente=self.cliente,
             fecha="2024-01-01",
             descripcion="Pedido inicial",
             total=100,
         )
-
-    def test_edit_pedido(self):
-        self.client.force_login(self.user)
         response = self.client.post(
-            reverse("pedido_editar", args=[self.pedido.pk]),
+            reverse("pedido_editar", args=[pedido.pk]),
             {
                 "cliente": self.cliente.pk,
                 "presupuesto": "",
@@ -73,8 +86,113 @@ class PedidoEditTests(TestCase):
                 "total": 200,
             },
         )
-        self.assertRedirects(response, reverse("pedidos_list"))
-        self.pedido.refresh_from_db()
-        self.assertEqual(self.pedido.descripcion, "Pedido actualizado")
-        self.assertEqual(self.pedido.total, 200)
+        self.assertRedirects(response, reverse("pedidos_list"), fetch_redirect_response=False)
+        pedido.refresh_from_db()
+        self.assertEqual(pedido.descripcion, "Pedido actualizado")
+        self.assertEqual(pedido.total, 200)
 
+    def test_export_csv(self):
+        Pedido.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            fecha="2024-01-01",
+            descripcion="Export CSV",
+            total=100,
+        )
+        response = self.client.get(reverse("pedido_export_csv"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Cliente", response.content)
+
+    def test_export_pdf(self):
+        Pedido.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            fecha="2024-01-01",
+            descripcion="Export PDF",
+            total=100,
+        )
+        response = self.client.get(reverse("pedido_export_pdf"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertTrue(response.content.startswith(b"%PDF"))
+
+
+class ActuacionCRUDTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="user", password="pass")
+        self.client.force_login(self.user)
+        self.cliente = Cliente.objects.create(usuario=self.user, nombre="Cliente")
+        self.pedido = Pedido.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            fecha="2024-01-01",
+            descripcion="Pedido",
+            total=100,
+        )
+
+    def test_create_actuacion(self):
+        response = self.client.post(
+            reverse("actuacion_nueva"),
+            {
+                "cliente": self.cliente.pk,
+                "pedido": self.pedido.pk,
+                "fecha": "2024-01-02",
+                "descripcion": "Trabajo",
+                "coste": 50,
+            },
+        )
+        self.assertRedirects(response, reverse("actuaciones_list"), fetch_redirect_response=False)
+        self.assertEqual(Actuacion.objects.count(), 1)
+
+    def test_edit_actuacion(self):
+        act = Actuacion.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            pedido=self.pedido,
+            fecha="2024-01-02",
+            descripcion="Vieja",
+            coste=50,
+        )
+        response = self.client.post(
+            reverse("actuacion_editar", args=[act.pk]),
+            {
+                "cliente": self.cliente.pk,
+                "pedido": self.pedido.pk,
+                "fecha": "2024-01-03",
+                "descripcion": "Nueva",
+                "coste": 80,
+            },
+        )
+        self.assertRedirects(response, reverse("actuaciones_list"), fetch_redirect_response=False)
+        act.refresh_from_db()
+        self.assertEqual(act.descripcion, "Nueva")
+        self.assertEqual(act.coste, 80)
+
+    def test_delete_actuacion(self):
+        act = Actuacion.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            pedido=self.pedido,
+            fecha="2024-01-02",
+            descripcion="Borrar",
+            coste=50,
+        )
+        response = self.client.post(
+            reverse("actuacion_eliminar", args=[act.pk])
+        )
+        self.assertRedirects(response, reverse("actuaciones_list"), fetch_redirect_response=False)
+        self.assertEqual(Actuacion.objects.count(), 0)
+
+    def test_export_csv(self):
+        Actuacion.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            pedido=self.pedido,
+            fecha="2024-01-02",
+            descripcion="Export",
+            coste=50,
+        )
+        response = self.client.get(reverse("actuaciones_export_csv"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Export", response.content)

--- a/core/views.py
+++ b/core/views.py
@@ -29,7 +29,9 @@ def cliente_nuevo(request):
     if request.method == 'POST':
         form = ClienteForm(request.POST)
         if form.is_valid():
-            form.save()
+            cliente = form.save(commit=False)
+            cliente.usuario = request.user
+            cliente.save()
             return redirect('clientes_list')
     else:
         form = ClienteForm()
@@ -133,7 +135,9 @@ def actuacion_nueva(request):
     if request.method == 'POST':
         form = ActuacionForm(request.POST)
         if form.is_valid():
-            form.save()
+            actuacion = form.save(commit=False)
+            actuacion.usuario = request.user
+            actuacion.save()
             return redirect('actuaciones_list')
     else:
         form = ActuacionForm()

--- a/fapp/settings_test.py
+++ b/fapp/settings_test.py
@@ -1,0 +1,14 @@
+from .settings import *
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+MIGRATION_MODULES = {
+    "core": None,
+    "clientes": None,
+    "presupuestos": None,
+}

--- a/presupuestos/tests.py
+++ b/presupuestos/tests.py
@@ -1,3 +1,97 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from core.models import Cliente, Presupuesto
 
-# Create your tests here.
+
+class PresupuestoCRUDTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="user", password="pass")
+        self.client.force_login(self.user)
+        self.cliente = Cliente.objects.create(usuario=self.user, nombre="Cliente")
+
+    def test_create_presupuesto(self):
+        response = self.client.post(
+            reverse("presupuesto_create"),
+            {
+                "cliente": self.cliente.pk,
+                "fecha": "2024-01-01",
+                "concepto": "Trabajo",
+                "total": 100,
+            },
+        )
+        self.assertRedirects(response, reverse("presupuesto_list"), fetch_redirect_response=False)
+        self.assertEqual(Presupuesto.objects.count(), 1)
+
+    def test_update_presupuesto(self):
+        presupuesto = Presupuesto.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            fecha="2024-01-01",
+            concepto="Viejo",
+            total=100,
+        )
+        response = self.client.post(
+            reverse("presupuesto_update", args=[presupuesto.pk]),
+            {
+                "cliente": self.cliente.pk,
+                "fecha": "2024-01-02",
+                "concepto": "Nuevo",
+                "total": 200,
+            },
+        )
+        self.assertRedirects(response, reverse("presupuesto_list"), fetch_redirect_response=False)
+        presupuesto.refresh_from_db()
+        self.assertEqual(presupuesto.concepto, "Nuevo")
+        self.assertEqual(presupuesto.total, 200)
+
+    def test_delete_presupuesto(self):
+        presupuesto = Presupuesto.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            fecha="2024-01-01",
+            concepto="Borrar",
+            total=100,
+        )
+        response = self.client.post(
+            reverse("presupuesto_delete", args=[presupuesto.pk])
+        )
+        self.assertRedirects(response, reverse("presupuesto_list"), fetch_redirect_response=False)
+        self.assertEqual(Presupuesto.objects.count(), 0)
+
+    def test_list_presupuestos(self):
+        Presupuesto.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            fecha="2024-01-01",
+            concepto="Listado",
+            total=100,
+        )
+        response = self.client.get(reverse("presupuesto_list"))
+        self.assertContains(response, "Cliente")
+
+    def test_export_csv(self):
+        Presupuesto.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            fecha="2024-01-01",
+            concepto="CSV",
+            total=100,
+        )
+        response = self.client.get(reverse("presupuesto_export_csv"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Cliente", response.content)
+
+    def test_export_pdf(self):
+        Presupuesto.objects.create(
+            usuario=self.user,
+            cliente=self.cliente,
+            fecha="2024-01-01",
+            concepto="PDF",
+            total=100,
+        )
+        response = self.client.get(reverse("presupuesto_export_pdf"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertTrue(response.content.startswith(b"%PDF"))

--- a/test_urls.py
+++ b/test_urls.py
@@ -1,0 +1,13 @@
+from django.urls import include, path
+from django.http import HttpResponse
+
+
+def dummy_view(request):
+    return HttpResponse("")
+
+urlpatterns = [
+    path('', include(('clientes.urls', 'clientes'), namespace='clientes')),
+    path('logout/', dummy_view, name='logout'),
+    path('dashboard/', dummy_view, name='dashboard'),
+    path('clientes-list/', dummy_view, name='clientes_list'),
+]


### PR DESCRIPTION
## Summary
- Add tests for client, order, action and budget CRUD workflows including CSV/PDF export checks
- Configure SQLite-based test settings and auxiliary URLs for isolated testing
- Run test suite in GitHub Actions

## Testing
- `python manage.py test --settings=fapp.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_689474f34f288321904cddf80b2eb8ff