### PR TITLE
Read security settings from environment

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,6 +18,18 @@ Configuración del entorno
    ```
 
 
+Variables de entorno
+--------------------
+
+Antes de ejecutar el proyecto, define las siguientes variables de entorno:
+
+```bash
+export SECRET_KEY='tu-clave-secreta'
+export DEBUG='False'  # o 'True' en desarrollo
+export ALLOWED_HOSTS='localhost,127.0.0.1'
+```
+
+
 Dependencias
 ------------
 

--- a/fapp/settings.py
+++ b/fapp/settings.py
@@ -3,11 +3,15 @@ import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-clave-secreta')
+SECRET_KEY = os.environ["SECRET_KEY"]
 
-DEBUG = os.environ.get('DEBUG', 'True') == 'True'
+DEBUG = os.environ.get("DEBUG", "False").lower() in ("true", "1")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = (
+    os.environ.get("ALLOWED_HOSTS", "").split(",")
+    if os.environ.get("ALLOWED_HOSTS")
+    else []
+)
 
 INSTALLED_APPS = [
     'django.contrib.admin',
@@ -67,7 +71,20 @@ DATABASES = {
     }
 }
 
-AUTH_PASSWORD_VALIDATORS = []
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
 
 LANGUAGE_CODE = 'es-es'
 


### PR DESCRIPTION
## Summary
- Load SECRET_KEY, DEBUG, and ALLOWED_HOSTS from environment variables
- Add Django's default AUTH_PASSWORD_VALIDATORS
- Document required environment variables in README

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68947b102f2c8321af6833f1befda5dd