### PR TITLE
Remove duplicate __str__ in Actuacion

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -71,12 +71,8 @@ class Actuacion(models.Model):
     descripcion = models.TextField()
     coste = models.DecimalField(max_digits=10, decimal_places=2)
 
-
     def __str__(self) -> str:  # pragma: no cover - string representation
         return f"Actuación #{self.pk} - {self.cliente.nombre}"
-
-    def __str__(self):
-        return f'Actuación de Pedido #{self.pedido.pk}'
 
 
 class Factura(models.Model):


### PR DESCRIPTION
## Summary
- remove duplicate `__str__` in `Actuacion` model to keep a single consistent string representation

## Testing
- `python manage.py makemigrations` *(fails: closing parenthesis does not match opening bracket in `core/migrations/0001_initial.py`)*
- `python manage.py test` *(fails: connection to PostgreSQL server at `localhost:5432` refused)*

------
https://chatgpt.com/codex/tasks/task_e_68947b1783d483219a7597547d99bb2f