### PR TITLE
Remove outdated localidad references

### DIFF
--- a/core/templates/core/clientes_list.html
+++ b/core/templates/core/clientes_list.html
@@ -39,7 +39,6 @@
                 <th>CIF</th>
                 <th>Email</th>
                 <th>Teléfono</th>
-                <th>Localidad</th>
                 <th class="text-center">Activo</th>
                 <th class="text-center">Acciones</th>
               </tr>
@@ -51,7 +50,6 @@
                 <td>{{ cliente.cif }}</td>
                 <td>{{ cliente.email }}</td>
                 <td>{{ cliente.telefono }}</td>
-                <td>{{ cliente.localidad }}</td>
                 <td class="text-center">
                   {% if cliente.activo %}
                     <span class="text-success">●</span>
@@ -67,7 +65,7 @@
                 </td>
               </tr>
               {% empty %}
-              <tr><td colspan="7" class="text-center text-muted">No hay clientes.</td></tr>
+              <tr><td colspan="6" class="text-center text-muted">No hay clientes.</td></tr>
               {% endfor %}
             </tbody>
           </table>

--- a/core/views_export.py
+++ b/core/views_export.py
@@ -11,11 +11,11 @@ def cliente_export_csv(request):
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="clientes.csv"'
     writer = csv.writer(response)
-    writer.writerow(['Nombre', 'CIF', 'Email', 'Teléfono', 'Localidad', 'Activo'])
+    writer.writerow(['Nombre', 'CIF', 'Email', 'Teléfono', 'Activo'])
 
     clientes = Cliente.objects.filter(usuario=request.user) if request.user.rol != 'admin' else Cliente.objects.all()
     for c in clientes:
-        writer.writerow([c.nombre, c.cif, c.email, c.telefono, c.localidad, 'Sí' if c.activo else 'No'])
+        writer.writerow([c.nombre, c.cif, c.email, c.telefono, 'Sí' if c.activo else 'No'])
 
     return response
 


### PR DESCRIPTION
## Summary
- remove obsolete `localidad` column from client list template
- drop `localidad` field from client CSV export

## Testing
- `python manage.py test --settings=fapp.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_68947b18af7c8321996ecd03584e30ff