### PR TITLE
Remove duplicate imports in views

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2,16 +2,13 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from .models import Cliente, Pedido, Actuacion, Factura
-from django.http import HttpResponse
-from django.template.loader import render_to_string
+from django.template.loader import get_template, render_to_string
 import csv
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
 from .forms import ClienteForm, PedidoForm, ActuacionForm, FacturaForm
-from django.template.loader import get_template
 from xhtml2pdf import pisa
 from .utils import export_csv, export_pdf, render_html
-
 
 
 @login_required


### PR DESCRIPTION
## Summary
- deduplicate HttpResponse import in core views
- combine template loader imports into a single line

## Testing
- `flake8 core/views.py | head -n 5`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68947b1b03d08321a0b2264baafdef7c