### PR TITLE
Refactor cliente templates to top-level versions

### DIFF
--- a/core/templates/core/clientes/cliente_form.html
+++ b/core/templates/core/clientes/cliente_form.html
@@ -1,1 +1,0 @@
-<h1>Formulario de cliente</h1>

--- a/core/templates/core/clientes/clientes_list.html
+++ b/core/templates/core/clientes/clientes_list.html
@@ -1,1 +1,0 @@
-<h1>Listado de clientes</h1>

--- a/core/views.py
+++ b/core/views.py
@@ -22,32 +22,40 @@ def dashboard(request):
 @login_required
 def clientes_list(request):
     clientes = Cliente.objects.all()
-    return render(request, 'core/clientes/clientes_list.html', {'clientes': clientes})
+    return render(request, 'core/clientes_list.html', {"clientes": clientes})
 
 @login_required
 def cliente_nuevo(request):
-    if request.method == 'POST':
+    if request.method == "POST":
         form = ClienteForm(request.POST)
         if form.is_valid():
             cliente = form.save(commit=False)
             cliente.usuario = request.user
             cliente.save()
-            return redirect('clientes_list')
+            return redirect("clientes_list")
     else:
         form = ClienteForm()
-    return render(request, 'core/clientes/cliente_form.html', {'form': form})
+    return render(
+        request,
+        "core/cliente_form.html",
+        {"form": form, "modo": "nuevo"},
+    )
 
 @login_required
 def cliente_editar(request, pk):
     cliente = get_object_or_404(Cliente, pk=pk)
-    if request.method == 'POST':
+    if request.method == "POST":
         form = ClienteForm(request.POST, instance=cliente)
         if form.is_valid():
             form.save()
-            return redirect('clientes_list')
+            return redirect("clientes_list")
     else:
         form = ClienteForm(instance=cliente)
-    return render(request, 'core/clientes/cliente_form.html', {'form': form})
+    return render(
+        request,
+        "core/cliente_form.html",
+        {"form": form, "modo": "editar"},
+    )
 
 @login_required
 def cliente_export_csv(request):


### PR DESCRIPTION
## Summary
- Repoint cliente views to consolidated `core/cliente_form.html` and `core/clientes_list.html`
- Remove obsolete `core/clientes/*` template stubs
- Pass `modo` context to cliente forms for template headers

## Testing
- `python manage.py test --settings=fapp.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_68947b1c25108321ac4b5ec656be257d