### PR TITLE
Filtra vistas por usuario y añade tests de acceso

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from .models import Cliente, Pedido, Factura, Actuacion
@@ -196,3 +196,145 @@ class ActuacionCRUDTests(TestCase):
         response = self.client.get(reverse("actuaciones_export_csv"))
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Export", response.content)
+
+
+@override_settings(
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "APP_DIRS": False,
+            "OPTIONS": {
+                "loaders": [
+                    (
+                        "django.template.loaders.locmem.Loader",
+                        {
+                            "core/clientes/clientes_list.html": "{% for c in clientes %}{{ c.nombre }}{% endfor %}",
+                            "core/pedidos/pedidos_list.html": "{% for p in pedidos %}{{ p.descripcion }}{% endfor %}",
+                            "core/actuaciones/actuaciones_list.html": "{% for a in actuaciones %}{{ a.descripcion }}{% endfor %}",
+                            "core/facturas/facturas_list.html": "{% for f in facturas %}{{ f.numero }}{% endfor %}",
+                        },
+                    )
+                ]
+            },
+        }
+    ]
+)
+class AccessControlTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user1 = User.objects.create_user(username="user1", password="pass")
+        self.user2 = User.objects.create_user(username="user2", password="pass")
+
+        self.cliente1 = Cliente.objects.create(usuario=self.user1, nombre="Cliente1")
+        self.cliente2 = Cliente.objects.create(usuario=self.user2, nombre="Cliente2")
+
+        self.pedido1 = Pedido.objects.create(
+            usuario=self.user1,
+            cliente=self.cliente1,
+            fecha="2024-01-01",
+            descripcion="Pedido1",
+            total=100,
+        )
+        self.pedido2 = Pedido.objects.create(
+            usuario=self.user2,
+            cliente=self.cliente2,
+            fecha="2024-01-01",
+            descripcion="Pedido2",
+            total=200,
+        )
+
+        self.actuacion1 = Actuacion.objects.create(
+            usuario=self.user1,
+            cliente=self.cliente1,
+            pedido=self.pedido1,
+            fecha="2024-01-02",
+            descripcion="Act1",
+            coste=50,
+        )
+        self.actuacion2 = Actuacion.objects.create(
+            usuario=self.user2,
+            cliente=self.cliente2,
+            pedido=self.pedido2,
+            fecha="2024-01-02",
+            descripcion="Act2",
+            coste=60,
+        )
+
+        self.factura1 = Factura.objects.create(
+            usuario=self.user1,
+            cliente=self.cliente1,
+            pedido=self.pedido1,
+            actuacion=self.actuacion1,
+            fecha="2024-01-03",
+            numero="F1",
+            base_imponible=100,
+            iva=21,
+            irpf=0,
+        )
+        self.factura2 = Factura.objects.create(
+            usuario=self.user2,
+            cliente=self.cliente2,
+            pedido=self.pedido2,
+            actuacion=self.actuacion2,
+            fecha="2024-01-03",
+            numero="F2",
+            base_imponible=100,
+            iva=21,
+            irpf=0,
+        )
+
+    def test_clientes_list_filters_user(self):
+        self.client.force_login(self.user1)
+        response = self.client.get(reverse("clientes_list"))
+        self.assertContains(response, "Cliente1")
+        self.assertNotContains(response, "Cliente2")
+
+    def test_clientes_list_requires_login(self):
+        response = self.client.get(reverse("clientes_list"))
+        self.assertRedirects(
+            response,
+            f"/accounts/login/?next={reverse('clientes_list')}",
+            fetch_redirect_response=False,
+        )
+
+    def test_pedidos_list_filters_user(self):
+        self.client.force_login(self.user1)
+        response = self.client.get(reverse("pedidos_list"))
+        self.assertContains(response, "Pedido1")
+        self.assertNotContains(response, "Pedido2")
+
+    def test_pedidos_list_requires_login(self):
+        response = self.client.get(reverse("pedidos_list"))
+        self.assertRedirects(
+            response,
+            f"/accounts/login/?next={reverse('pedidos_list')}",
+            fetch_redirect_response=False,
+        )
+
+    def test_actuaciones_list_filters_user(self):
+        self.client.force_login(self.user1)
+        response = self.client.get(reverse("actuaciones_list"))
+        self.assertContains(response, "Act1")
+        self.assertNotContains(response, "Act2")
+
+    def test_actuaciones_list_requires_login(self):
+        response = self.client.get(reverse("actuaciones_list"))
+        self.assertRedirects(
+            response,
+            f"/accounts/login/?next={reverse('actuaciones_list')}",
+            fetch_redirect_response=False,
+        )
+
+    def test_facturas_list_filters_user(self):
+        self.client.force_login(self.user1)
+        response = self.client.get(reverse("facturas_list"))
+        self.assertContains(response, "F1")
+        self.assertNotContains(response, "F2")
+
+    def test_facturas_list_requires_login(self):
+        response = self.client.get(reverse("facturas_list"))
+        self.assertRedirects(
+            response,
+            f"/accounts/login/?next={reverse('facturas_list')}",
+            fetch_redirect_response=False,
+        )

--- a/core/views.py
+++ b/core/views.py
@@ -21,7 +21,7 @@ def dashboard(request):
 # --- Clientes ---
 @login_required
 def clientes_list(request):
-    clientes = Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     return render(request, 'core/clientes/clientes_list.html', {'clientes': clientes})
 
 @login_required
@@ -39,7 +39,7 @@ def cliente_nuevo(request):
 
 @login_required
 def cliente_editar(request, pk):
-    cliente = get_object_or_404(Cliente, pk=pk)
+    cliente = get_object_or_404(Cliente, pk=pk, usuario=request.user)
     if request.method == 'POST':
         form = ClienteForm(request.POST, instance=cliente)
         if form.is_valid():
@@ -51,7 +51,7 @@ def cliente_editar(request, pk):
 
 @login_required
 def cliente_export_csv(request):
-    queryset = Cliente.objects.all()
+    queryset = Cliente.objects.filter(usuario=request.user)
     fields = [
         ('nombre', 'Nombre'),
         ('email', 'Email'),
@@ -62,20 +62,20 @@ def cliente_export_csv(request):
 
 @login_required
 def cliente_export_pdf(request):
-    clientes = Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     context = {'clientes': clientes}
     return export_pdf('core/clientes_pdf.html', context, 'clientes.pdf')
 
 
 @login_required
 def cliente_print_html(request):
-    clientes = Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     context = {'clientes': clientes}
     return render_html('core/clientes_pdf.html', context)
 
 @login_required
 def pedidos_list(request):
-    pedidos = Pedido.objects.all()
+    pedidos = Pedido.objects.filter(usuario=request.user)
     return render(request, 'core/pedidos/pedidos_list.html', {'pedidos': pedidos})
 
 @login_required
@@ -93,7 +93,7 @@ def pedido_nuevo(request):
 
 @login_required
 def pedido_editar(request, pk):
-    pedido = get_object_or_404(Pedido, pk=pk)
+    pedido = get_object_or_404(Pedido, pk=pk, usuario=request.user)
     if request.method == 'POST':
         form = PedidoForm(request.POST, instance=pedido)
         if form.is_valid():
@@ -109,13 +109,13 @@ def pedido_export_csv(request):
     response['Content-Disposition'] = 'attachment; filename="pedidos.csv"'
     writer = csv.writer(response)
     writer.writerow(['Fecha', 'Cliente', 'Presupuesto', 'Total'])
-    for p in Pedido.objects.all():
+    for p in Pedido.objects.filter(usuario=request.user):
         writer.writerow([p.fecha, p.cliente.nombre, p.presupuesto.id if p.presupuesto else '', p.total])
     return response
 
 @login_required
 def pedido_export_pdf(request):
-    pedidos = Pedido.objects.all()
+    pedidos = Pedido.objects.filter(usuario=request.user)
     template = get_template('core/pedidos/pedidos_pdf.html')
     html = template.render({'pedidos': pedidos})
     response = HttpResponse(content_type='application/pdf')
@@ -127,7 +127,7 @@ def pedido_export_pdf(request):
 # --- Actuaciones ---
 @login_required
 def actuaciones_list(request):
-    actuaciones = Actuacion.objects.all()
+    actuaciones = Actuacion.objects.filter(usuario=request.user)
     return render(request, 'core/actuaciones/actuaciones_list.html', {'actuaciones': actuaciones})
 
 @login_required
@@ -145,7 +145,7 @@ def actuacion_nueva(request):
 
 @login_required
 def actuacion_editar(request, pk):
-    actuacion = get_object_or_404(Actuacion, pk=pk)
+    actuacion = get_object_or_404(Actuacion, pk=pk, usuario=request.user)
     if request.method == 'POST':
         form = ActuacionForm(request.POST, instance=actuacion)
         if form.is_valid():
@@ -157,7 +157,7 @@ def actuacion_editar(request, pk):
 
 @login_required
 def actuacion_eliminar(request, pk):
-    actuacion = get_object_or_404(Actuacion, pk=pk)
+    actuacion = get_object_or_404(Actuacion, pk=pk, usuario=request.user)
     if request.method == 'POST':
         actuacion.delete()
         return redirect('actuaciones_list')
@@ -169,14 +169,14 @@ def actuaciones_export_csv(request):
     response['Content-Disposition'] = 'attachment; filename="actuaciones.csv"'
     writer = csv.writer(response)
     writer.writerow(['Pedido', 'Fecha', 'Descripción', 'Coste'])
-    for act in Actuacion.objects.all():
+    for act in Actuacion.objects.filter(usuario=request.user):
         writer.writerow([act.pedido.id, act.fecha, act.descripcion, act.coste])
     return response
 
 # --- Facturas ---
 @login_required
 def facturas_list(request):
-    facturas = Factura.objects.all()
+    facturas = Factura.objects.filter(usuario=request.user)
     return render(
         request, "core/facturas/facturas_list.html", {"facturas": facturas}
     )
@@ -198,7 +198,7 @@ def factura_nueva(request):
 
 @login_required
 def factura_editar(request, pk):
-    factura = get_object_or_404(Factura, pk=pk)
+    factura = get_object_or_404(Factura, pk=pk, usuario=request.user)
     if request.method == "POST":
         form = FacturaForm(request.POST, instance=factura)
         if form.is_valid():
@@ -215,14 +215,14 @@ def factura_export_csv(request):
     response["Content-Disposition"] = 'attachment; filename="facturas.csv"'
     writer = csv.writer(response)
     writer.writerow(["Número", "Cliente", "Total"])
-    for factura in Factura.objects.all():
+    for factura in Factura.objects.filter(usuario=request.user):
         writer.writerow([factura.numero, factura.cliente.nombre, factura.total])
     return response
 
 
 @login_required
 def factura_export_html(request):
-    facturas = Factura.objects.all()
+    facturas = Factura.objects.filter(usuario=request.user)
     html = render_to_string(
         "core/facturas/facturas_export.html", {"facturas": facturas}
     )
@@ -238,7 +238,7 @@ def factura_export_pdf(request):
     p = canvas.Canvas(response, pagesize=letter)
     y = 770
     p.drawString(80, 800, "Listado de facturas")
-    for factura in Factura.objects.all():
+    for factura in Factura.objects.filter(usuario=request.user):
         p.drawString(
             80,
             y,


### PR DESCRIPTION
## Summary
- Restringe consultas de clientes, pedidos, actuaciones y facturas al usuario autenticado
- Añade pruebas para verificar el aislamiento de datos y la redirección a login

## Testing
- `python manage.py test --settings=fapp.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_68947b1d7230832199cce33769d514a5