### PR TITLE
Handle missing fields in CSV export

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,7 +1,10 @@
 import csv
+import logging
 from django.http import HttpResponse
 from django.template.loader import get_template
 from xhtml2pdf import pisa
+
+logger = logging.getLogger(__name__)
 
 
 def export_csv(queryset, fields, filename="export.csv"):
@@ -21,7 +24,11 @@ def export_csv(queryset, fields, filename="export.csv"):
         row = []
         for field in fields:
             attr = field[0] if isinstance(field, (tuple, list)) else field
-            value = getattr(obj, attr)
+            try:
+                value = getattr(obj, attr)
+            except Exception as e:
+                logger.error("Failed to get attribute '%s' from %r: %s", attr, obj, e)
+                value = ""
             row.append(value)
         writer.writerow(row)
     return response


### PR DESCRIPTION
## Summary
- log and fallback to blank when export_csv encounters missing attributes
- test missing fields export and logging

## Testing
- `python manage.py test --settings=fapp.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_68947b21ef5c8321a25b42d46b16c856