### PR TITLE
Filtrado por usuario en exportaciones de clientes

### DIFF
--- a/clientes/views.py
+++ b/clientes/views.py
@@ -9,7 +9,7 @@ from core.models import Cliente
 
 
 def cliente_list(request):
-    clientes = Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     return render(request, 'clientes/cliente_list.html', {'clientes': clientes})
 
 
@@ -53,7 +53,7 @@ def cliente_export_csv(request):
     response['Content-Disposition'] = 'attachment; filename="clientes.csv"'
     writer = csv.writer(response)
     writer.writerow(['Nombre', 'Email', 'Telefono', 'Direccion'])
-    for c in Cliente.objects.all():
+    for c in Cliente.objects.filter(usuario=request.user):
         writer.writerow([c.nombre, c.email, c.telefono, c.direccion])
     return response
 
@@ -62,7 +62,7 @@ def cliente_export_pdf(request):
     buffer = BytesIO()
     p = canvas.Canvas(buffer)
     y = 800
-    for c in Cliente.objects.all():
+    for c in Cliente.objects.filter(usuario=request.user):
         p.drawString(50, y, f"{c.nombre} - {c.email or ''} - {c.telefono or ''}")
         y -= 20
         if y < 50:
@@ -75,5 +75,5 @@ def cliente_export_pdf(request):
 
 
 def cliente_print(request):
-    clientes = Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     return render(request, 'clientes/clientes_print.html', {'clientes': clientes})

--- a/core/templates/core/clientes_list.html
+++ b/core/templates/core/clientes_list.html
@@ -39,7 +39,7 @@
                 <th>CIF</th>
                 <th>Email</th>
                 <th>Teléfono</th>
-                <th>Localidad</th>
+                <th>Dirección</th>
                 <th class="text-center">Activo</th>
                 <th class="text-center">Acciones</th>
               </tr>
@@ -51,7 +51,7 @@
                 <td>{{ cliente.cif }}</td>
                 <td>{{ cliente.email }}</td>
                 <td>{{ cliente.telefono }}</td>
-                <td>{{ cliente.localidad }}</td>
+                <td>{{ cliente.direccion }}</td>
                 <td class="text-center">
                   {% if cliente.activo %}
                     <span class="text-success">●</span>

--- a/core/views_export.py
+++ b/core/views_export.py
@@ -11,17 +11,17 @@ def cliente_export_csv(request):
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="clientes.csv"'
     writer = csv.writer(response)
-    writer.writerow(['Nombre', 'CIF', 'Email', 'Teléfono', 'Localidad', 'Activo'])
+    writer.writerow(['Nombre', 'CIF', 'Email', 'Teléfono', 'Dirección', 'Activo'])
 
-    clientes = Cliente.objects.filter(usuario=request.user) if request.user.rol != 'admin' else Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     for c in clientes:
-        writer.writerow([c.nombre, c.cif, c.email, c.telefono, c.localidad, 'Sí' if c.activo else 'No'])
+        writer.writerow([c.nombre, c.cif, c.email, c.telefono, c.direccion, 'Sí' if c.activo else 'No'])
 
     return response
 
 @login_required
 def cliente_export_pdf(request):
-    clientes = Cliente.objects.filter(usuario=request.user) if request.user.rol != 'admin' else Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     template = get_template('core/clientes_pdf.html')
     html = template.render({'clientes': clientes})
     response = HttpResponse(content_type='application/pdf')

--- a/test_urls.py
+++ b/test_urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('logout/', dummy_view, name='logout'),
     path('dashboard/', dummy_view, name='dashboard'),
     path('clientes-list/', dummy_view, name='clientes_list'),
+    path('presupuestos/', dummy_view, name='presupuestos_list'),
 ]


### PR DESCRIPTION
## Summary
- Filtra las exportaciones de clientes por el usuario autenticado y elimina referencias obsoletas a `rol` y `localidad`.
- La vista y plantilla de clientes muestran la dirección y respetan el ámbito del usuario.
- Las pruebas comprueban que listados y exportaciones no incluyan datos de otros usuarios.

## Testing
- `python manage.py test --settings=fapp.settings_test`

------
https://chatgpt.com/codex/tasks/task_e_68947b23e780832192d88d47c267c01f