### PR TITLE
Fix clientes list template fields

### DIFF
--- a/core/templates/core/clientes_list.html
+++ b/core/templates/core/clientes_list.html
@@ -39,7 +39,7 @@
                 <th>CIF</th>
                 <th>Email</th>
                 <th>Teléfono</th>
-                <th>Localidad</th>
+                <th>Dirección</th>
                 <th class="text-center">Activo</th>
                 <th class="text-center">Acciones</th>
               </tr>
@@ -51,7 +51,7 @@
                 <td>{{ cliente.cif }}</td>
                 <td>{{ cliente.email }}</td>
                 <td>{{ cliente.telefono }}</td>
-                <td>{{ cliente.localidad }}</td>
+                <td>{{ cliente.direccion }}</td>
                 <td class="text-center">
                   {% if cliente.activo %}
                     <span class="text-success">●</span>
@@ -61,9 +61,6 @@
                 </td>
                 <td class="text-center text-nowrap">
                   <a href="{% url 'cliente_editar' cliente.id %}" class="btn btn-sm btn-warning">Editar</a>
-                  <a href="{% url 'cliente_toggle' cliente.id %}" class="btn btn-sm btn-outline-dark">
-                    {% if cliente.activo %}Desactivar{% else %}Activar{% endif %}
-                  </a>
                 </td>
               </tr>
               {% empty %}

--- a/core/views.py
+++ b/core/views.py
@@ -22,7 +22,7 @@ def dashboard(request):
 @login_required
 def clientes_list(request):
     clientes = Cliente.objects.all()
-    return render(request, 'core/clientes/clientes_list.html', {'clientes': clientes})
+    return render(request, 'core/clientes_list.html', {'clientes': clientes})
 
 @login_required
 def cliente_nuevo(request):


### PR DESCRIPTION
## Summary
- Replace nonexistent `localidad` column with `dirección` and remove missing `cliente_toggle` link
- Point client list view at the updated template

## Testing
- `python manage.py test --settings=fapp.settings_test`
- `python manage.py shell --settings=fapp.settings_test <<'PY'
from django.core.management import call_command
from django.conf import settings
from types import ModuleType
from django.urls import path, include
from django.http import HttpResponse
import sys

module = ModuleType('temp_urls')
module.urlpatterns = [
    path('logout/', lambda request: HttpResponse(''), name='logout'),
    path('presupuestos/', lambda request: HttpResponse(''), name='presupuestos_list'),
    path('', include('core.urls')),
]
sys.modules['temp_urls'] = module
settings.ROOT_URLCONF = 'temp_urls'
settings.ALLOWED_HOSTS = ['testserver']

call_command('migrate', run_syncdb=True, verbosity=0)

from django.test import Client
from django.contrib.auth import get_user_model
from core.models import Cliente
User = get_user_model()
user = User.objects.create_user(username='test', password='pass')
Cliente.objects.create(usuario=user, nombre='Juan', cif='12345678A', direccion='Calle 1', email='juan@example.com', telefono='123456789')
client = Client()
client.login(username='test', password='pass')
response = client.get('/clientes/')
print('status', response.status_code)
print('Dirección' in response.content.decode())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68947b2651f4832196327186d6ad279e