### PR TITLE
Protect client views with login

### DIFF
--- a/clientes/tests.py
+++ b/clientes/tests.py
@@ -57,3 +57,33 @@ class ClienteCRUDTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/pdf")
         self.assertTrue(response.content.startswith(b"%PDF"))
+
+
+@override_settings(ROOT_URLCONF="test_urls")
+class ClienteLoginRequiredTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="user2", password="pass")
+        self.cliente = Cliente.objects.create(usuario=self.user, nombre="Cli")
+
+    def assert_login_redirect(self, url, method="get"):
+        client_method = getattr(self.client, method)
+        response = client_method(url)
+        self.assertRedirects(
+            response,
+            f"/accounts/login/?next={url}",
+            fetch_redirect_response=False,
+        )
+
+    def test_login_required_views(self):
+        urls = [
+            reverse("clientes:cliente_create"),
+            reverse("clientes:cliente_edit", args=[self.cliente.pk]),
+            reverse("clientes:cliente_delete", args=[self.cliente.pk]),
+            reverse("clientes:cliente_export_csv"),
+            reverse("clientes:cliente_export_pdf"),
+            reverse("clientes:cliente_print"),
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                self.assert_login_redirect(url)

--- a/clientes/views.py
+++ b/clientes/views.py
@@ -3,16 +3,18 @@ import csv
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from reportlab.pdfgen import canvas
+from django.contrib.auth.decorators import login_required
 
 from .forms import ClienteForm
 from core.models import Cliente
 
-
+@login_required
 def cliente_list(request):
     clientes = Cliente.objects.all()
     return render(request, 'clientes/cliente_list.html', {'clientes': clientes})
 
 
+@login_required
 def cliente_create(request):
     if request.method == 'POST':
         form = ClienteForm(request.POST)
@@ -26,6 +28,7 @@ def cliente_create(request):
     return render(request, 'clientes/cliente_form.html', {'form': form})
 
 
+@login_required
 def cliente_edit(request, pk):
     cliente = get_object_or_404(Cliente, pk=pk)
     if request.method == 'POST':
@@ -40,6 +43,7 @@ def cliente_edit(request, pk):
     return render(request, 'clientes/cliente_form.html', {'form': form})
 
 
+@login_required
 def cliente_delete(request, pk):
     cliente = get_object_or_404(Cliente, pk=pk)
     if request.method == 'POST':
@@ -48,6 +52,7 @@ def cliente_delete(request, pk):
     return render(request, 'clientes/cliente_confirm_delete.html', {'cliente': cliente})
 
 
+@login_required
 def cliente_export_csv(request):
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="clientes.csv"'
@@ -58,6 +63,7 @@ def cliente_export_csv(request):
     return response
 
 
+@login_required
 def cliente_export_pdf(request):
     buffer = BytesIO()
     p = canvas.Canvas(buffer)
@@ -74,6 +80,7 @@ def cliente_export_pdf(request):
     return HttpResponse(buffer, content_type='application/pdf')
 
 
+@login_required
 def cliente_print(request):
     clientes = Cliente.objects.all()
     return render(request, 'clientes/clientes_print.html', {'clientes': clientes})

--- a/fapp/urls.py
+++ b/fapp/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('', include('core.urls')),
     path('presupuestos/', include('presupuestos.urls')),
     path('clientes/', include(('clientes.urls', 'clientes'), namespace='clientes')),
+    path('accounts/', include('django.contrib.auth.urls')),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## Summary
- require authentication for all client views
- hook up Django's auth URL patterns
- test that protected views redirect anonymous users to login

## Testing
- `python manage.py test --settings=fapp.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_68947b29a6c08321928a63478942f2e9