### PR TITLE
Restringir acceso a clientes por usuario

### DIFF
--- a/clientes/tests.py
+++ b/clientes/tests.py
@@ -57,3 +57,40 @@ class ClienteCRUDTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/pdf")
         self.assertTrue(response.content.startswith(b"%PDF"))
+
+    def test_list_shows_only_user_clients(self):
+        Cliente.objects.create(usuario=self.user, nombre="Mine")
+        other_user = get_user_model().objects.create_user("other")
+        Cliente.objects.create(usuario=other_user, nombre="Other")
+        response = self.client.get(reverse("clientes:cliente_list"))
+        self.assertContains(response, "Mine")
+        self.assertNotContains(response, "Other")
+
+    def test_cannot_edit_other_user_cliente(self):
+        other_user = get_user_model().objects.create_user("other")
+        other_cliente = Cliente.objects.create(usuario=other_user, nombre="Other")
+        response = self.client.get(reverse("clientes:cliente_edit", args=[other_cliente.pk]))
+        self.assertEqual(response.status_code, 404)
+
+    def test_cannot_delete_other_user_cliente(self):
+        other_user = get_user_model().objects.create_user("other")
+        other_cliente = Cliente.objects.create(usuario=other_user, nombre="Other")
+        response = self.client.post(reverse("clientes:cliente_delete", args=[other_cliente.pk]))
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(Cliente.objects.filter(pk=other_cliente.pk).exists())
+
+    def test_export_csv_excludes_other_user_clients(self):
+        Cliente.objects.create(usuario=self.user, nombre="Mine")
+        other_user = get_user_model().objects.create_user("other")
+        Cliente.objects.create(usuario=other_user, nombre="Other")
+        response = self.client.get(reverse("clientes:cliente_export_csv"))
+        self.assertIn(b"Mine", response.content)
+        self.assertNotIn(b"Other", response.content)
+
+    def test_export_pdf_excludes_other_user_clients(self):
+        Cliente.objects.create(usuario=self.user, nombre="Mine")
+        other_user = get_user_model().objects.create_user("other")
+        Cliente.objects.create(usuario=other_user, nombre="Other")
+        response = self.client.get(reverse("clientes:cliente_export_pdf"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b"Other", response.content)

--- a/clientes/views.py
+++ b/clientes/views.py
@@ -9,7 +9,7 @@ from core.models import Cliente
 
 
 def cliente_list(request):
-    clientes = Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     return render(request, 'clientes/cliente_list.html', {'clientes': clientes})
 
 
@@ -27,7 +27,7 @@ def cliente_create(request):
 
 
 def cliente_edit(request, pk):
-    cliente = get_object_or_404(Cliente, pk=pk)
+    cliente = get_object_or_404(Cliente, pk=pk, usuario=request.user)
     if request.method == 'POST':
         form = ClienteForm(request.POST, instance=cliente)
         if form.is_valid():
@@ -41,7 +41,7 @@ def cliente_edit(request, pk):
 
 
 def cliente_delete(request, pk):
-    cliente = get_object_or_404(Cliente, pk=pk)
+    cliente = get_object_or_404(Cliente, pk=pk, usuario=request.user)
     if request.method == 'POST':
         cliente.delete()
         return redirect('clientes:cliente_list')
@@ -53,7 +53,7 @@ def cliente_export_csv(request):
     response['Content-Disposition'] = 'attachment; filename="clientes.csv"'
     writer = csv.writer(response)
     writer.writerow(['Nombre', 'Email', 'Telefono', 'Direccion'])
-    for c in Cliente.objects.all():
+    for c in Cliente.objects.filter(usuario=request.user):
         writer.writerow([c.nombre, c.email, c.telefono, c.direccion])
     return response
 
@@ -62,7 +62,7 @@ def cliente_export_pdf(request):
     buffer = BytesIO()
     p = canvas.Canvas(buffer)
     y = 800
-    for c in Cliente.objects.all():
+    for c in Cliente.objects.filter(usuario=request.user):
         p.drawString(50, y, f"{c.nombre} - {c.email or ''} - {c.telefono or ''}")
         y -= 20
         if y < 50:
@@ -75,5 +75,5 @@ def cliente_export_pdf(request):
 
 
 def cliente_print(request):
-    clientes = Cliente.objects.all()
+    clientes = Cliente.objects.filter(usuario=request.user)
     return render(request, 'clientes/clientes_print.html', {'clientes': clientes})

--- a/test_urls.py
+++ b/test_urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('logout/', dummy_view, name='logout'),
     path('dashboard/', dummy_view, name='dashboard'),
     path('clientes-list/', dummy_view, name='clientes_list'),
+    path('presupuestos/', dummy_view, name='presupuestos_list'),
 ]


### PR DESCRIPTION
## Summary
- Filtra listados, ediciones y borrados de clientes al usuario autenticado.
- Aplica el mismo filtro en exportaciones CSV y PDF.
- Añade pruebas que impiden acceder a clientes ajenos.

## Testing
- `python manage.py test --settings=fapp.settings_test`

------
https://chatgpt.com/codex/tasks/task_e_68947b2b87848321826ef9e6912e4e2c