### PR TITLE
Limit form field querysets to user

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,9 +1,12 @@
 from django import forms
-from presupuestos.forms import PresupuestoForm
-from .models import Cliente, Pedido, Actuacion, Factura
+from .models import Cliente, Pedido, Actuacion, Factura, Presupuesto
 
 
 class ClienteForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+
     class Meta:
         model = Cliente
         fields = ['nombre', 'email', 'telefono', 'direccion', 'activo']
@@ -24,6 +27,17 @@ class ClienteForm(forms.ModelForm):
 
 
 class PedidoForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if self.request:
+            self.fields['cliente'].queryset = Cliente.objects.filter(
+                usuario=self.request.user
+            )
+            self.fields['presupuesto'].queryset = Presupuesto.objects.filter(
+                usuario=self.request.user
+            )
+
     class Meta:
         model = Pedido
         fields = ['cliente', 'presupuesto', 'fecha', 'descripcion', 'total']
@@ -44,6 +58,17 @@ class PedidoForm(forms.ModelForm):
 
 
 class ActuacionForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if self.request:
+            self.fields['cliente'].queryset = Cliente.objects.filter(
+                usuario=self.request.user
+            )
+            self.fields['pedido'].queryset = Pedido.objects.filter(
+                usuario=self.request.user
+            )
+
     class Meta:
         model = Actuacion
         fields = ['cliente', 'pedido', 'fecha', 'descripcion', 'coste']
@@ -67,6 +92,21 @@ class FacturaForm(forms.ModelForm):
         label='Total (€)', required=False, disabled=True,
         widget=forms.NumberInput(attrs={'class': 'form-control'})
     )
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if self.request:
+            self.fields['cliente'].queryset = Cliente.objects.filter(
+                usuario=self.request.user
+            )
+            self.fields['pedido'].queryset = Pedido.objects.filter(
+                usuario=self.request.user
+            )
+            self.fields['actuacion'].queryset = Actuacion.objects.filter(
+                usuario=self.request.user
+            )
+
     class Meta:
         model = Factura
         fields = ['cliente', 'pedido', 'actuacion', 'fecha', 'numero', 'base_imponible', 'iva', 'irpf', 'estado']

--- a/core/views.py
+++ b/core/views.py
@@ -24,14 +24,14 @@ def clientes_list(request):
 @login_required
 def cliente_nuevo(request):
     if request.method == "POST":
-        form = ClienteForm(request.POST)
+        form = ClienteForm(request.POST, request=request)
         if form.is_valid():
             cliente = form.save(commit=False)
             cliente.usuario = request.user
             cliente.save()
             return redirect("clientes_list")
     else:
-        form = ClienteForm()
+        form = ClienteForm(request=request)
     return render(
         request,
         "core/clientes/cliente_form.html",
@@ -43,12 +43,12 @@ def cliente_editar(request, pk):
 
     cliente = get_object_or_404(Cliente, pk=pk, usuario=request.user)
     if request.method == 'POST':
-        form = ClienteForm(request.POST, instance=cliente)
+        form = ClienteForm(request.POST, instance=cliente, request=request)
         if form.is_valid():
             form.save()
             return redirect("clientes_list")
     else:
-        form = ClienteForm(instance=cliente)
+        form = ClienteForm(instance=cliente, request=request)
     return render(
         request,
         "core/clientes/cliente_form.html",
@@ -93,26 +93,26 @@ def pedidos_list(request):
 @login_required
 def pedido_nuevo(request):
     if request.method == 'POST':
-        form = PedidoForm(request.POST)
+        form = PedidoForm(request.POST, request=request)
         if form.is_valid():
             pedido = form.save(commit=False)
             pedido.usuario = request.user
             pedido.save()
             return redirect('pedidos_list')
     else:
-        form = PedidoForm()
+        form = PedidoForm(request=request)
     return render(request, 'core/pedidos/pedido_form.html', {'form': form, 'modo': 'nuevo'})
 
 @login_required
 def pedido_editar(request, pk):
     pedido = get_object_or_404(Pedido, pk=pk, usuario=request.user)
     if request.method == 'POST':
-        form = PedidoForm(request.POST, instance=pedido)
+        form = PedidoForm(request.POST, instance=pedido, request=request)
         if form.is_valid():
             form.save()
             return redirect('pedidos_list')
     else:
-        form = PedidoForm(instance=pedido)
+        form = PedidoForm(instance=pedido, request=request)
     return render(request, 'core/pedidos/pedido_form.html', {'form': form, 'modo': 'editar'})
 
 @login_required
@@ -148,26 +148,26 @@ def actuaciones_list(request):
 @login_required
 def actuacion_nueva(request):
     if request.method == 'POST':
-        form = ActuacionForm(request.POST)
+        form = ActuacionForm(request.POST, request=request)
         if form.is_valid():
             actuacion = form.save(commit=False)
             actuacion.usuario = request.user
             actuacion.save()
             return redirect('actuaciones_list')
     else:
-        form = ActuacionForm()
+        form = ActuacionForm(request=request)
     return render(request, 'core/actuaciones/actuacion_form.html', {'form': form})
 
 @login_required
 def actuacion_editar(request, pk):
     actuacion = get_object_or_404(Actuacion, pk=pk, usuario=request.user)
     if request.method == 'POST':
-        form = ActuacionForm(request.POST, instance=actuacion)
+        form = ActuacionForm(request.POST, instance=actuacion, request=request)
         if form.is_valid():
             form.save()
             return redirect('actuaciones_list')
     else:
-        form = ActuacionForm(instance=actuacion)
+        form = ActuacionForm(instance=actuacion, request=request)
     return render(request, 'core/actuaciones/actuacion_form.html', {'form': form})
 
 @login_required
@@ -200,14 +200,14 @@ def facturas_list(request):
 @login_required
 def factura_nueva(request):
     if request.method == "POST":
-        form = FacturaForm(request.POST)
+        form = FacturaForm(request.POST, request=request)
         if form.is_valid():
             factura = form.save(commit=False)
             factura.usuario = request.user
             factura.save()
             return redirect("facturas_list")
     else:
-        form = FacturaForm()
+        form = FacturaForm(request=request)
     return render(request, "core/facturas/factura_form.html", {"form": form})
 
 
@@ -215,12 +215,12 @@ def factura_nueva(request):
 def factura_editar(request, pk):
     factura = get_object_or_404(Factura, pk=pk, usuario=request.user)
     if request.method == "POST":
-        form = FacturaForm(request.POST, instance=factura)
+        form = FacturaForm(request.POST, instance=factura, request=request)
         if form.is_valid():
             form.save()
             return redirect("facturas_list")
     else:
-        form = FacturaForm(instance=factura)
+        form = FacturaForm(instance=factura, request=request)
     return render(request, "core/facturas/factura_form.html", {"form": form})
 
 

--- a/presupuestos/forms.py
+++ b/presupuestos/forms.py
@@ -1,7 +1,15 @@
 from django import forms
-from core.models import Presupuesto
+from core.models import Presupuesto, Cliente
 
 class PresupuestoForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if self.request:
+            self.fields['cliente'].queryset = Cliente.objects.filter(
+                usuario=self.request.user
+            )
+
     class Meta:
         model = Presupuesto
         fields = ['cliente', 'fecha', 'concepto', 'total']

--- a/presupuestos/views.py
+++ b/presupuestos/views.py
@@ -14,7 +14,7 @@ def presupuesto_list(request):
 
 @login_required
 def presupuesto_create(request):
-    form = PresupuestoForm(request.POST or None)
+    form = PresupuestoForm(request.POST or None, request=request)
     if form.is_valid():
         presupuesto = form.save(commit=False)
         presupuesto.usuario = request.user
@@ -25,7 +25,7 @@ def presupuesto_create(request):
 @login_required
 def presupuesto_update(request, pk):
     presupuesto = get_object_or_404(Presupuesto, pk=pk)
-    form = PresupuestoForm(request.POST or None, instance=presupuesto)
+    form = PresupuestoForm(request.POST or None, instance=presupuesto, request=request)
     if form.is_valid():
         presupuesto = form.save(commit=False)
         presupuesto.usuario = request.user


### PR DESCRIPTION
## Summary
- ensure core and presupuestos forms accept request and filter foreign key fields to the current user's data
- pass request objects from views when instantiating forms

## Testing
- `USE_SQLITE=1 SECRET_KEY=test python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689499d3571083219a5a2d4d9fa05e1b