### PR TITLE
Use development default for SECRET_KEY

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -29,6 +29,10 @@ export DEBUG='False'  # o 'True' en desarrollo
 export ALLOWED_HOSTS='localhost,127.0.0.1'
 ```
 
+Si no defines `SECRET_KEY`, el proyecto utilizará un valor por defecto
+válido solo para entornos de desarrollo. **En producción debes establecer
+siempre esta variable.**
+
 
 Dependencias
 ------------

--- a/fapp/settings.py
+++ b/fapp/settings.py
@@ -3,7 +3,9 @@ import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-SECRET_KEY = os.environ["SECRET_KEY"]
+# En producción este valor debe definirse mediante la variable de entorno
+# SECRET_KEY. El valor por defecto sólo debe usarse durante el desarrollo.
+SECRET_KEY = os.environ.get("SECRET_KEY", "definir-en-produccion")
 
 DEBUG = os.environ.get("DEBUG", "False").lower() in ("true", "1")
 


### PR DESCRIPTION
## Summary
- handle missing SECRET_KEY env var with safe development default
- document that default key is only for development use

## Testing
- `USE_SQLITE=1 python manage.py test` *(fails: AssertionError and redirect mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6894aa05697883218d2b777240d7201f