### PR TITLE
Simplify Django template directories

### DIFF
--- a/fapp/settings.py
+++ b/fapp/settings.py
@@ -47,7 +47,7 @@ ROOT_URLCONF = 'fapp.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'templates', BASE_DIR / 'core' / 'templates'],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/templates/.gitkeep
+++ b/templates/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for root templates


### PR DESCRIPTION
## Summary
- Create project-level `templates/` directory
- Remove `core/templates` from TEMPLATES `DIRS` since `APP_DIRS` handles app templates

## Testing
- `USE_SQLITE=1 python manage.py test` *(fails: failures=44)*

------
https://chatgpt.com/codex/tasks/task_e_6894abdd3dc08321864e9d55f49e3863