### PR TITLE
Add startup checks for DB config and dependencies

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -62,12 +62,22 @@ Base de datos
 3. Configura las variables de entorno para la conexión:
 
    ```bash
-   export POSTGRES_DB=fappdb
-   export POSTGRES_USER=fappuser
-   export POSTGRES_PASSWORD=fapppass
-   export POSTGRES_HOST=localhost
-   export POSTGRES_PORT=5432
-   ```
+    export POSTGRES_DB=fappdb
+    export POSTGRES_USER=fappuser
+    export POSTGRES_PASSWORD=fapppass
+    export POSTGRES_HOST=localhost
+    export POSTGRES_PORT=5432
+```
+
+Configuración en nuevos entornos
+-------------------------------
+
+Al iniciar la aplicación se verifica que las librerías externas
+`xhtml2pdf` y `reportlab` estén instaladas y que la conexión con la base
+de datos sea posible. Si falta alguna de estas dependencias o las
+variables de entorno `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`,
+`POSTGRES_HOST` o `POSTGRES_PORT`, se mostrará un mensaje de error
+descriptivo para facilitar la configuración del entorno.
 
 Migraciones y servidor
 ----------------------

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,6 +1,34 @@
+import importlib
+
 from django.apps import AppConfig
+from django.db import connections
+from django.db.utils import OperationalError
 
 
 class CoreConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'core'
+
+    def ready(self):
+        self._check_external_libs()
+        self._check_database_connection()
+
+    def _check_external_libs(self):
+        for lib in ("xhtml2pdf", "reportlab"):
+            try:
+                importlib.import_module(lib)
+            except ImportError as exc:
+                raise RuntimeError(
+                    f"No se pudo importar la librería externa '{lib}'. "
+                    "Instálala en el entorno antes de continuar."
+                ) from exc
+
+    def _check_database_connection(self):
+        db_conn = connections["default"]
+        try:
+            db_conn.cursor()
+        except OperationalError as exc:
+            raise RuntimeError(
+                "No se pudo conectar a la base de datos. Revisa la "
+                "configuración y que el servidor esté disponible."
+            ) from exc

--- a/fapp/settings.py
+++ b/fapp/settings.py
@@ -1,7 +1,19 @@
 from pathlib import Path
 import os
+import importlib
+
+from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+
+def get_env(name, default=None, required=False):
+    """Obtiene una variable de entorno o lanza un error descriptivo."""
+    value = os.environ.get(name, default)
+    if required and value is None:
+        raise ImproperlyConfigured(
+            f"Falta la variable de entorno {name} para la configuración.")
+    return value
 
 # En producción este valor debe definirse mediante la variable de entorno
 # SECRET_KEY. El valor por defecto sólo debe usarse durante el desarrollo.
@@ -70,14 +82,22 @@ if os.environ.get("USE_SQLITE") == "1":
         }
     }
 else:
+    try:
+        importlib.import_module("psycopg2")
+    except Exception as exc:
+        raise ImproperlyConfigured(
+            "La librería 'psycopg2-binary' es necesaria para PostgreSQL. "
+            "Instálala con 'pip install psycopg2-binary'."
+        ) from exc
+
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': os.getenv('POSTGRES_DB', 'fappdb'),
-            'USER': os.getenv('POSTGRES_USER', 'fappuser'),
-            'PASSWORD': os.getenv('POSTGRES_PASSWORD', 'fapppass'),
-            'HOST': os.getenv('POSTGRES_HOST', 'localhost'),
-            'PORT': os.getenv('POSTGRES_PORT', '5432'),
+            'NAME': get_env('POSTGRES_DB', required=True),
+            'USER': get_env('POSTGRES_USER', required=True),
+            'PASSWORD': get_env('POSTGRES_PASSWORD', required=True),
+            'HOST': get_env('POSTGRES_HOST', required=True),
+            'PORT': get_env('POSTGRES_PORT', required=True),
         }
     }
 


### PR DESCRIPTION
## Summary
- validate required environment variables and psycopg2 on PostgreSQL setups
- verify external libraries and database connection on application startup
- document configuration checks for new environments

## Testing
- `USE_SQLITE=1 SECURE_SSL_REDIRECT=False DJANGO_SETTINGS_MODULE=fapp.settings_test python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6894b48ba9348321a70f67edfaeb8e14