### PR TITLE
Add admin configurations for core models

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,9 +1,67 @@
-from django.contrib import admin
-from .models import Usuario, Cliente, Presupuesto, Pedido, Actuacion, Factura
+"""Admin configuration for core models."""
 
-admin.site.register(Usuario)
-admin.site.register(Cliente)
-admin.site.register(Presupuesto)
-admin.site.register(Pedido)
-admin.site.register(Actuacion)
-admin.site.register(Factura)
+from django.contrib import admin
+
+from .models import Actuacion, Cliente, Factura, Pedido, Presupuesto, Usuario
+
+
+@admin.register(Usuario)
+class UsuarioAdmin(admin.ModelAdmin):
+    """Admin options for :class:`Usuario`."""
+
+    list_display = [
+        "username",
+        "email",
+        "first_name",
+        "last_name",
+        "telefono",
+        "is_staff",
+    ]
+    search_fields = ["username", "email", "first_name", "last_name"]
+    list_filter = ["is_staff", "is_superuser", "is_active"]
+
+
+@admin.register(Cliente)
+class ClienteAdmin(admin.ModelAdmin):
+    """Admin options for :class:`Cliente`."""
+
+    list_display = ["nombre", "cif", "email", "telefono", "activo"]
+    search_fields = ["nombre", "cif", "email"]
+    list_filter = ["activo"]
+
+
+@admin.register(Presupuesto)
+class PresupuestoAdmin(admin.ModelAdmin):
+    """Admin options for :class:`Presupuesto`."""
+
+    list_display = ["cliente", "fecha", "concepto", "total"]
+    search_fields = ["cliente__nombre", "concepto"]
+    list_filter = ["fecha", "cliente"]
+
+
+@admin.register(Pedido)
+class PedidoAdmin(admin.ModelAdmin):
+    """Admin options for :class:`Pedido`."""
+
+    list_display = ["cliente", "fecha", "descripcion", "total"]
+    search_fields = ["cliente__nombre", "descripcion"]
+    list_filter = ["fecha", "cliente"]
+
+
+@admin.register(Actuacion)
+class ActuacionAdmin(admin.ModelAdmin):
+    """Admin options for :class:`Actuacion`."""
+
+    list_display = ["cliente", "pedido", "fecha", "coste"]
+    search_fields = ["cliente__nombre", "pedido__descripcion", "descripcion"]
+    list_filter = ["fecha", "cliente"]
+
+
+@admin.register(Factura)
+class FacturaAdmin(admin.ModelAdmin):
+    """Admin options for :class:`Factura`."""
+
+    list_display = ["numero", "cliente", "fecha", "total", "estado"]
+    search_fields = ["numero", "cliente__nombre"]
+    list_filter = ["fecha", "estado", "cliente"]
+


### PR DESCRIPTION
## Summary
- define custom ModelAdmin classes for Usuario, Cliente, Presupuesto, Pedido, Actuacion, and Factura
- register models with the Django admin using decorators

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6894bfa5f1e8832183a37d908b6dfe16