### PR TITLE
Refactor clientes CRUD to class-based views

### DIFF
--- a/clientes/urls.py
+++ b/clientes/urls.py
@@ -1,14 +1,22 @@
 from django.urls import path
-from . import views
+from .views import (
+    ClienteListView,
+    ClienteCreateView,
+    ClienteUpdateView,
+    ClienteDeleteView,
+    cliente_export_csv,
+    cliente_export_pdf,
+    cliente_print,
+)
 
 app_name = 'clientes'
 
 urlpatterns = [
-    path('', views.cliente_list, name='cliente_list'),
-    path('nuevo/', views.cliente_create, name='cliente_create'),
-    path('editar/<int:pk>/', views.cliente_edit, name='cliente_edit'),
-    path('eliminar/<int:pk>/', views.cliente_delete, name='cliente_delete'),
-    path('exportar/csv/', views.cliente_export_csv, name='cliente_export_csv'),
-    path('exportar/pdf/', views.cliente_export_pdf, name='cliente_export_pdf'),
-    path('imprimir/', views.cliente_print, name='cliente_print'),
+    path('', ClienteListView.as_view(), name='cliente_list'),
+    path('nuevo/', ClienteCreateView.as_view(), name='cliente_create'),
+    path('editar/<int:pk>/', ClienteUpdateView.as_view(), name='cliente_edit'),
+    path('eliminar/<int:pk>/', ClienteDeleteView.as_view(), name='cliente_delete'),
+    path('exportar/csv/', cliente_export_csv, name='cliente_export_csv'),
+    path('exportar/pdf/', cliente_export_pdf, name='cliente_export_pdf'),
+    path('imprimir/', cliente_print, name='cliente_print'),
 ]

--- a/core/templates/core/clientes/cliente_confirm_delete.html
+++ b/core/templates/core/clientes/cliente_confirm_delete.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card">
   <div class="card-body">
-    <p>¿Seguro que deseas eliminar a {{ cliente.nombre }}?</p>
+    <p>¿Seguro que deseas eliminar a {{ object.nombre }}?</p>
     <form method="post">
       {% csrf_token %}
       <button type="submit" class="btn btn-danger">Eliminar</button>

--- a/core/templates/core/clientes/cliente_list.html
+++ b/core/templates/core/clientes/cliente_list.html
@@ -22,7 +22,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for cliente in clientes %}
+        {% for cliente in object_list %}
         <tr>
           <td>{{ cliente.nombre }}</td>
           <td>{{ cliente.email }}</td>


### PR DESCRIPTION
## Summary
- Replace cliente CRUD function views with class-based views
- Align cliente templates with CBV context conventions
- Update cliente URLs to point to new CBVs

## Testing
- `USE_SQLITE=1 SECURE_SSL_REDIRECT=False DJANGO_SETTINGS_MODULE=fapp.settings_test python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6894c23316408321b1ae0b2c2fed75e2